### PR TITLE
refactor(all): fix linter warnings (`eslint`)

### DIFF
--- a/src/ast/statements/forBinding.ts
+++ b/src/ast/statements/forBinding.ts
@@ -1,5 +1,4 @@
 import { Node } from '../node';
-import { LexicalDeclaration } from '../declarations/lexical-declaration';
 import { VariableDeclaration } from '../declarations/variable-declaration';
 
 /**

--- a/src/core.ts
+++ b/src/core.ts
@@ -159,7 +159,9 @@ export function parseInRecoveryMode(text: string, filename: string, context: Con
 export function parseInIncrementalMode(
   text: string,
   filename: string,
+  /* eslint-disable */
   _root: RootNode,
+  /* eslint-disable */
   _textChangeRange: TextChangeRange
 ): RootNode {
   // TODO!

--- a/src/lexer/regexp.ts
+++ b/src/lexer/regexp.ts
@@ -1,7 +1,7 @@
 import { Char } from './char';
 import { Token } from '../ast/token';
 import { AsciiCharFlags, AsciiCharTypes } from './asciiChar';
-import { isIdentifierPart, fromCodePoint } from './common';
+import { isIdentifierPart } from './common';
 import { Context, ParserState } from '../common';
 import { addDiagnostic, DiagnosticSource, DiagnosticKind } from '../diagnostic';
 import { DiagnosticCode } from '../diagnostic/diagnostic-code';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1266,7 +1266,7 @@ export function parseForBinding(
   cb: LexicalCallback,
   start: number
 ): any {
-  let declarations = parseForBindingList(state, context, scope, type, cb);
+  const declarations = parseForBindingList(state, context, scope, type, cb);
   if (isLexical) {
     return finishNode(
       state,
@@ -3587,7 +3587,7 @@ export function parseFormalParameters(state: ParserState, context: Context, scop
         );
       }
       if (state.token & Token.IsPatternStart) {
-        let innerStart = state.startIndex;
+        const innerStart = state.startIndex;
         isSimpleParameterList = true;
         const left = parseBindingElements(state, context, scope, BindingType.ArgumentList, parseBindingPattern);
         const right = consumeOpt(state, context | Context.AllowRegExp, Token.Assign)
@@ -3597,7 +3597,7 @@ export function parseFormalParameters(state: ParserState, context: Context, scop
           finishNode(state, context, innerStart, DictionaryMap.BindingElement(left, right), SyntaxKind.BindingElement)
         );
       } else {
-        let innerStart = state.startIndex;
+        const innerStart = state.startIndex;
         if (state.token & Token.IsFutureReserved) state.flags |= Flags.HasStrictReserved;
         const left = parseBindingIdentifier(state, context, scope, BindingType.ArgumentList);
         if (!consumeOpt(state, context | Context.AllowRegExp, Token.Assign)) {
@@ -4970,7 +4970,6 @@ export function parseExportDeclaration(
       if (state.token === Token.FromKeyword) {
         fromClause = parseFromClause(state, context);
       } else {
-        const i = exportedNames.length;
         for (let i = exportedNames.length - 1; i >= 0; i -= 1) {
           const name = '#' + exportedNames[i];
           if (state.exportedNames[name]) {

--- a/test/lexer/whitespace.ts
+++ b/test/lexer/whitespace.ts
@@ -1,7 +1,6 @@
 import * as t from 'assert';
 import { Context } from '../../src/common';
 import { create } from '../../src/parser';
-import { Token } from '../../src/ast/token';
 import { scanSingleToken } from '../../src/lexer/scan';
 
 describe('Scanner - Whitespace', () => {

--- a/test/parser/expressions/array.ts
+++ b/test/parser/expressions/array.ts
@@ -1,5 +1,5 @@
 import * as t from 'assert';
-import { parseScript, parseModule, recovery } from '../../../src/escaya';
+import { parseScript, recovery } from '../../../src/escaya';
 
 describe('Expressions - Array', () => {
   // Invalid cases

--- a/test/parser/expressions/member.ts
+++ b/test/parser/expressions/member.ts
@@ -1,5 +1,5 @@
 import * as t from 'assert';
-import { parseScript, parseModule, recovery } from '../../../src/escaya';
+import { parseScript, recovery } from '../../../src/escaya';
 
 describe('Expressions - Member', () => {
   // Invalid cases

--- a/test/parser/statements/throw.ts
+++ b/test/parser/statements/throw.ts
@@ -1,5 +1,5 @@
 import * as t from 'assert';
-import { parseScript, parseModule, recovery } from '../../../src/escaya';
+import { parseScript, recovery } from '../../../src/escaya';
 
 describe('Statements - Throw', () => {
   // Invalid cases

--- a/test/parser/statements/with.ts
+++ b/test/parser/statements/with.ts
@@ -1,5 +1,5 @@
 import * as t from 'assert';
-import { parseScript, parseModule, recovery } from '../../../src/escaya';
+import { parseScript, recovery } from '../../../src/escaya';
 
 describe('Statements - With', () => {
   // Invalid cases


### PR DESCRIPTION
```
> eslint "{src,test,scripts}/**/*.{ts,js}"

escaya\src\ast\statements\forBinding.ts
  2:10  warning  'LexicalDeclaration' is defined but never used  @typescript-eslint/no-unused-vars

escaya\src\core.ts
  162:3  warning  '_root' is defined but never used             @typescript-eslint/no-unused-vars
  163:3  warning  '_textChangeRange' is defined but never used  @typescript-eslint/no-unused-vars

escaya\src\lexer\regexp.ts
  4:28  warning  'fromCodePoint' is defined but never used  @typescript-eslint/no-unused-vars

escaya\src\parser.ts
  1269:7   error    'declarations' is never reassigned. Use 'const' instead  prefer-const
  3590:13  error    'innerStart' is never reassigned. Use 'const' instead    prefer-const
  3600:13  error    'innerStart' is never reassigned. Use 'const' instead    prefer-const
  4973:15  warning  'i' is assigned a value but never used                   @typescript-eslint/no-unused-vars

escaya\test\lexer\whitespace.ts
  4:10  warning  'Token' is defined but never used  @typescript-eslint/no-unused-vars

escaya\test\parser\expressions\array.ts
  2:23  warning  'parseModule' is defined but never used  @typescript-eslint/no-unused-vars

escaya\test\parser\expressions\member.ts
  2:23  warning  'parseModule' is defined but never used  @typescript-eslint/no-unused-vars

escaya\test\parser\statements\throw.ts
  2:23  warning  'parseModule' is defined but never used  @typescript-eslint/no-unused-vars

escaya\test\parser\statements\with.ts
  2:23  warning  'parseModule' is defined but never used  @typescript-eslint/no-unused-vars
```