### PR TITLE
WIP:  JSX AST specs from private code

### DIFF
--- a/src/ast/jsx/jsx-attribute-list.ts
+++ b/src/ast/jsx/jsx-attribute-list.ts
@@ -1,0 +1,28 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { JsxAttribute } from './jsx-attribute';
+import { JsxSpreadAttribute } from './jsx-spread-attribute';
+
+/**
+ * Jsx attributes list
+ */
+
+export interface JsxAttributesList extends Node {
+  readonly attributes: (JsxSpreadAttribute | JsxAttribute)[];
+}
+
+export function createJsxAttributesList(
+  attributes: (JsxSpreadAttribute | JsxAttribute)[],
+  start: number,
+  end: number
+): JsxAttributesList {
+  return {
+    kind: NodeKind.JsxAttributesList,
+    attributes,
+    flags: NodeFlags.None,
+    transformFlags: TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-attribute.ts
+++ b/src/ast/jsx/jsx-attribute.ts
@@ -1,0 +1,36 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { JsxIdentifier } from './jsx-identifier';
+import { JsxMemberExpression } from './jsx-member-expression';
+import { JsxNamespacedName } from './jsx-namespaced-name';
+import { StringLiteral } from '../expressions/string-literal';
+import { JsxFragment } from './jsx-fragment';
+import { JsxElement } from './jsx-element';
+import { JsxSelfClosingElement } from './jsx-self-closing-element';
+
+/**
+ * Jsx attribute
+ */
+
+export interface JsxAttribute extends Node {
+  readonly name: JsxIdentifier | JsxNamespacedName;
+  readonly initializer: StringLiteral | JsxMemberExpression | JsxFragment | JsxElement | JsxSelfClosingElement | null;
+}
+
+export function createJsxAttribute(
+  name: JsxIdentifier | JsxNamespacedName,
+  initializer: StringLiteral | JsxMemberExpression | JsxFragment | JsxElement | JsxSelfClosingElement | null,
+  start: number,
+  end: number
+): JsxAttribute {
+  return {
+    kind: NodeKind.JsxAttribute,
+    name,
+    initializer,
+    flags: NodeFlags.None,
+    transformFlags: name.transformFlags | TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-children-list.ts
+++ b/src/ast/jsx/jsx-children-list.ts
@@ -1,0 +1,29 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { JsxText } from './jsx-text';
+import { JsxMemberExpression } from './jsx-member-expression';
+import { JsxElement } from './jsx-element';
+import { JsxSelfClosingElement } from './jsx-self-closing-element';
+import { JsxFragment } from './jsx-fragment';
+
+/**
+ * Jsx children list
+ */
+
+export type JsxChild = JsxText | JsxMemberExpression | JsxElement | JsxSelfClosingElement | JsxFragment;
+
+export interface JsxChildrenList extends Node {
+  readonly children: JsxChild[] | any;
+}
+
+export function createJsxChildrenList(children: JsxChild[] | any, start: number, end: number): JsxChildrenList {
+  return {
+    kind: NodeKind.JsxChildrenList,
+    children,
+    flags: NodeFlags.None,
+    transformFlags: TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-closing-element.ts
+++ b/src/ast/jsx/jsx-closing-element.ts
@@ -1,0 +1,30 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { JsxIdentifier } from './jsx-identifier';
+import { JsxNamespacedName } from './jsx-namespaced-name';
+import { JsxTagNamePropertyAccess } from './jsx-tag-name-property-access';
+import { ThisExpression } from '../expressions/this-expr';
+
+/**
+ * Jsx closing element
+ */
+
+export interface JsxClosingElement extends Node {
+  readonly tagName: ThisExpression | JsxNamespacedName | JsxIdentifier | JsxTagNamePropertyAccess;
+}
+
+export function createJsxClosingElement(
+  tagName: ThisExpression | JsxNamespacedName | JsxIdentifier | JsxTagNamePropertyAccess,
+  start: number,
+  end: number
+): JsxClosingElement {
+  return {
+    kind: NodeKind.JsxClosingElement,
+    tagName,
+    flags: NodeFlags.None,
+    transformFlags: tagName.transformFlags | TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-closing-fragment.ts
+++ b/src/ast/jsx/jsx-closing-fragment.ts
@@ -1,0 +1,19 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+
+/**
+ * JsxClosingFragment
+ */
+
+export type JsxClosingFragment = Node;
+
+export function createJsxClosingFragment(start: number, end: number): JsxClosingFragment {
+  return {
+    kind: NodeKind.JsxClosingFragment,
+    flags: NodeFlags.None,
+    transformFlags: TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-element.ts
+++ b/src/ast/jsx/jsx-element.ts
@@ -1,0 +1,35 @@
+import { Node, NodeFlags, NodeKind } from '../node';
+import { JsxOpeningElement } from './jsx-opening-element';
+import { JsxClosingElement } from './jsx-closing-element';
+import { JsxChildrenList } from './jsx-children-list';
+
+/**
+ * JsxElement
+ */
+
+export interface JsxElement extends Node {
+  readonly openingElement: JsxOpeningElement;
+  readonly childrenList: JsxChildrenList;
+  readonly closingElement: JsxClosingElement;
+}
+
+export function createJsxElement(
+  openingElement: JsxOpeningElement,
+  childrenList: JsxChildrenList,
+  closingElement: JsxClosingElement,
+  start: number,
+  end: number
+): JsxElement {
+  return {
+    kind: NodeKind.JsxElement,
+    openingElement,
+    childrenList,
+    closingElement,
+    flags: NodeFlags.None,
+    transformFlags: openingElement.transformFlags | childrenList.transformFlags | closingElement.transformFlags,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-fragment.ts
+++ b/src/ast/jsx/jsx-fragment.ts
@@ -1,0 +1,35 @@
+import { Node, NodeFlags, NodeKind } from '../node';
+import { JsxClosingFragment } from './jsx-closing-fragment';
+import { JsxOpeningFragment } from './jsx-opening-fragment';
+import { JsxChildrenList } from './jsx-children-list';
+
+/**
+ * A JSX expression of the form <>...</>
+ */
+
+export interface JsxFragment extends Node {
+  readonly openingFragment: JsxOpeningFragment;
+  readonly childrenList: JsxChildrenList;
+  readonly closingFragment: JsxClosingFragment;
+}
+
+export function createJsxFragment(
+  openingFragment: JsxOpeningFragment,
+  childrenList: JsxChildrenList,
+  closingFragment: JsxClosingFragment,
+  start: number,
+  end: number
+): JsxFragment {
+  return {
+    kind: NodeKind.JsxFragment,
+    openingFragment,
+    childrenList,
+    closingFragment,
+    flags: NodeFlags.None,
+    transformFlags: openingFragment.transformFlags | closingFragment.transformFlags | closingFragment.transformFlags,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-identifier.ts
+++ b/src/ast/jsx/jsx-identifier.ts
@@ -1,0 +1,21 @@
+import { Node, NodeKind, NodeFlags, TransformFlags } from '../node';
+
+/**
+ * Jsx identifier
+ */
+export interface JsxIdentifier extends Node {
+  readonly text: string;
+}
+
+export function createJsxIdentifier(text: string, start: number, end: number): JsxIdentifier {
+  return {
+    kind: NodeKind.JsxIdentifier,
+    text,
+    flags: NodeFlags.None,
+    transformFlags: TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-member-expression.ts
+++ b/src/ast/jsx/jsx-member-expression.ts
@@ -1,0 +1,30 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { Expression } from '../expressions/index';
+
+/**
+ * JsxMemberExpression
+ */
+
+export interface JsxMemberExpression extends Node {
+  readonly ellipsis: boolean;
+  readonly expression: Expression | null;
+}
+
+export function createJsxMemberExpression(
+  ellipsis: boolean,
+  expression: Expression | null,
+  start: number,
+  end: number
+): JsxMemberExpression {
+  return {
+    kind: NodeKind.JsxMemberExpression,
+    ellipsis,
+    expression,
+    flags: NodeFlags.None,
+    transformFlags: TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-namespaced-name.ts
+++ b/src/ast/jsx/jsx-namespaced-name.ts
@@ -1,0 +1,30 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { JsxIdentifier } from './jsx-identifier';
+
+/**
+ * JsxOpeningElement
+ */
+
+export interface JsxNamespacedName extends Node {
+  readonly name: JsxIdentifier;
+  readonly namespace: JsxIdentifier;
+}
+
+export function createJsxNamespacedName(
+  name: JsxIdentifier,
+  namespace: JsxIdentifier,
+  start: number,
+  end: number
+): JsxNamespacedName {
+  return {
+    kind: NodeKind.JsxNamespacedName,
+    name,
+    namespace,
+    flags: NodeFlags.None,
+    transformFlags: TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-opening-element.ts
+++ b/src/ast/jsx/jsx-opening-element.ts
@@ -1,0 +1,37 @@
+import { Node, NodeFlags, NodeKind } from '../node';
+import { JsxIdentifier } from './jsx-identifier';
+import { JsxNamespacedName } from './jsx-namespaced-name';
+import { JsxTagNamePropertyAccess } from './jsx-tag-name-property-access';
+import { ThisExpression } from '../expressions/this-expr';
+import { JsxAttributesList } from './jsx-attribute-list';
+
+/**
+ * Jsx opening element
+ */
+
+export interface JsxOpeningElement extends Node {
+  readonly tagName: ThisExpression | JsxNamespacedName | JsxIdentifier | JsxTagNamePropertyAccess;
+  readonly attributesList: JsxAttributesList;
+  readonly typeArguments: any;
+}
+
+export function createJsxOpeningElement(
+  tagName: ThisExpression | JsxNamespacedName | JsxIdentifier | JsxTagNamePropertyAccess,
+  attributesList: JsxAttributesList,
+  typeArguments: any,
+  start: number,
+  end: number
+): JsxOpeningElement {
+  return {
+    kind: NodeKind.JsxOpeningElement,
+    tagName,
+    attributesList,
+    typeArguments,
+    flags: NodeFlags.None,
+    transformFlags: tagName.transformFlags | attributesList.transformFlags,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-opening-fragment.ts
+++ b/src/ast/jsx/jsx-opening-fragment.ts
@@ -1,0 +1,22 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { JsxFragment } from './jsx-fragment';
+
+/**
+ * The opening element of a <>...</> JsxFragment
+ */
+
+export interface JsxOpeningFragment extends Node {
+  readonly parent: JsxFragment | null;
+}
+
+export function createJsxOpeningFragment(start: number, end: number): JsxOpeningFragment {
+  return {
+    kind: NodeKind.JsxOpeningFragment,
+    flags: NodeFlags.None,
+    transformFlags: TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-self-closing-element.ts
+++ b/src/ast/jsx/jsx-self-closing-element.ts
@@ -1,0 +1,37 @@
+import { Node, NodeFlags, NodeKind } from '../node';
+import { JsxAttributesList } from './jsx-attribute-list';
+import { JsxIdentifier } from './jsx-identifier';
+import { JsxNamespacedName } from './jsx-namespaced-name';
+import { JsxTagNamePropertyAccess } from './jsx-tag-name-property-access';
+import { ThisExpression } from '../expressions/this-expr';
+
+/**
+ * JsxSelfClosingElement
+ */
+
+export interface JsxSelfClosingElement extends Node {
+  readonly tagName: ThisExpression | JsxNamespacedName | JsxIdentifier | JsxTagNamePropertyAccess;
+  readonly attributesList: JsxAttributesList;
+  readonly typeArguments: any;
+}
+
+export function createJsxSelfClosingElement(
+  tagName: ThisExpression | JsxNamespacedName | JsxIdentifier | JsxTagNamePropertyAccess,
+  attributesList: JsxAttributesList,
+  typeArguments: any,
+  start: number,
+  end: number
+): JsxSelfClosingElement {
+  return {
+    kind: NodeKind.JsxSelfClosingElement,
+    tagName,
+    attributesList,
+    typeArguments,
+    flags: NodeFlags.None,
+    transformFlags: tagName.transformFlags | attributesList.transformFlags,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-spread-attribute.ts
+++ b/src/ast/jsx/jsx-spread-attribute.ts
@@ -1,0 +1,23 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { Expression } from '../expressions';
+
+/**
+ * JsxSpreadAttribute
+ */
+
+export interface JsxSpreadAttribute extends Node {
+  readonly expression: Expression;
+}
+
+export function createJsxSpreadAttribute(expression: Expression, start: number, end: number): JsxSpreadAttribute {
+  return {
+    kind: NodeKind.JsxSpreadAttribute,
+    expression,
+    flags: NodeFlags.None,
+    transformFlags: expression.transformFlags | TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-tag-name-property-access.ts
+++ b/src/ast/jsx/jsx-tag-name-property-access.ts
@@ -1,0 +1,32 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { Expression } from '../expressions';
+import { ThisExpression } from '../expressions/this-expr';
+import { JsxIdentifier } from './jsx-identifier';
+
+/**
+ * JsxTagNamePropertyAccess
+ */
+
+export interface JsxTagNamePropertyAccess extends Node {
+  readonly member: Expression;
+  readonly expression: Expression | JsxIdentifier | ThisExpression;
+}
+
+export function createJsxTagNamePropertyAccess(
+  member: Expression,
+  expression: Expression | JsxIdentifier | ThisExpression,
+  start: number,
+  end: number
+): JsxTagNamePropertyAccess {
+  return {
+    kind: NodeKind.JsxTagNamePropertyAccess,
+    member,
+    expression,
+    flags: NodeFlags.None,
+    transformFlags: expression.transformFlags | TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}

--- a/src/ast/jsx/jsx-text.ts
+++ b/src/ast/jsx/jsx-text.ts
@@ -1,0 +1,24 @@
+import { Node, NodeFlags, NodeKind, TransformFlags } from '../node';
+import { JsxElement } from './jsx-element';
+
+/**
+ * Jsx Text
+ */
+
+export interface JsxText extends Node {
+  readonly text: string;
+  readonly parent: JsxElement | null;
+}
+
+export function createJsxText(text: string, start: number, end: number): JsxText {
+  return {
+    kind: NodeKind.JsxChildrenList,
+    text,
+    flags: NodeFlags.None,
+    transformFlags: TransformFlags.Jsx,
+    parent: null,
+    emitNode: null,
+    start,
+    end
+  };
+}


### PR DESCRIPTION
This PR contains JSX AST specs adopted from my private code.

**TODO**  It need to be adjusted to fit with Escaya AST.

@aladdin-add Here is the JSX specs. No time to adjust it right now. It's a raw copy directly from my private code.

I also have TypeScript AST specs but no point because Escaya can't support TypeScript parsing.